### PR TITLE
feat(integrations): Adding Integrations button via OpenInt 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mastra/pg": "^0.10.0",
         "@modelcontextprotocol/sdk": "^1.10.1",
         "@neondatabase/serverless": "^1.0.0",
-        "@openint/connect": "~1.1.1",
+        "@openint/connect": "~1.1.11",
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-dropdown-menu": "^2.1.12",
         "@radix-ui/react-label": "^2.1.3",
@@ -7008,20 +7008,20 @@
       }
     },
     "node_modules/@openint/connect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@openint/connect/-/connect-1.1.1.tgz",
-      "integrity": "sha512-P4854iVXC8qV25KGtn9gMbXRY5hJxrSrzt0SuidTveqiSUsIKlWIAD7plamrXqGdufyTTr8CpCvBvEPoorCkcg==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@openint/connect/-/connect-1.1.11.tgz",
+      "integrity": "sha512-Bt4GCv2IE/D5FkaMaJrqWDTawdfC2OnZWF10XN7MrFi5PmIJGYoJCyJa7WJ8pL1pznFRg6hnOHNcTyzyyPTNeQ==",
       "dependencies": {
-        "@openint/sdk": "~2.2.0"
+        "@openint/sdk": "~2.7.0"
       },
       "peerDependencies": {
         "react": "*"
       }
     },
     "node_modules/@openint/sdk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@openint/sdk/-/sdk-2.2.0.tgz",
-      "integrity": "sha512-Seyv5gMNqGtOVjB2hj03lt+AcvRFKyqnrToD+kFSFVmfIzGh2gsZVAOiOiiuIjoaxnncvnBl67hynGkskmdcCg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@openint/sdk/-/sdk-2.7.0.tgz",
+      "integrity": "sha512-LGWvaimZBQ/dNJ6i2ajdKdX4QlnDmlTU5UaElaG+SRlzZVzr9hVZ5WLq7uTehNib2GJ7atPjlR4+F62LRf18ng==",
       "license": "Apache-2.0"
     },
     "node_modules/@opentelemetry/api": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@mastra/pg": "^0.10.0",
         "@modelcontextprotocol/sdk": "^1.10.1",
         "@neondatabase/serverless": "^1.0.0",
+        "@openint/connect": "~1.1.1",
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-dropdown-menu": "^2.1.12",
         "@radix-ui/react-label": "^2.1.3",
@@ -7005,6 +7006,23 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@openint/connect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@openint/connect/-/connect-1.1.1.tgz",
+      "integrity": "sha512-P4854iVXC8qV25KGtn9gMbXRY5hJxrSrzt0SuidTveqiSUsIKlWIAD7plamrXqGdufyTTr8CpCvBvEPoorCkcg==",
+      "dependencies": {
+        "@openint/sdk": "~2.2.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@openint/sdk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@openint/sdk/-/sdk-2.2.0.tgz",
+      "integrity": "sha512-Seyv5gMNqGtOVjB2hj03lt+AcvRFKyqnrToD+kFSFVmfIzGh2gsZVAOiOiiuIjoaxnncvnBl67hynGkskmdcCg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "marked": "^15.0.8",
     "motion": "^12.7.4",
     "next": "15.3.0",
+    "@openint/connect": "~1.1.1",
     "next-themes": "^0.4.6",
     "pg": "8.14.1",
     "postcss": "^8.5.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "marked": "^15.0.8",
     "motion": "^12.7.4",
     "next": "15.3.0",
-    "@openint/connect": "~1.1.1",
+    "@openint/connect": "~1.1.11",
     "next-themes": "^0.4.6",
     "pg": "8.14.1",
     "postcss": "^8.5.3",

--- a/src/app/api/integration/route.ts
+++ b/src/app/api/integration/route.ts
@@ -1,0 +1,28 @@
+import { getUser } from "@/auth/stack-auth";
+import  {Openint}  from "@openint/connect";
+
+export async function POST(req: Request) {
+
+  // the backend will not return a token if the OPENINT_API_KEY is not set, making the <IntegrationsButton /> component render null
+  if (!process.env.OPENINT_API_KEY) {
+    return new Response(JSON.stringify({
+      token: null,
+    }), { status: 200 });
+  }
+  const {userId} = await getUser();
+
+  const openint = new Openint({
+    token: process.env.OPENINT_API_KEY,
+  });
+
+  try {
+  const {token} = await openint.createToken(userId, {});
+
+  return new Response(JSON.stringify({
+    token,
+  }));
+  } catch (error) {
+    console.error("Error creating Openint token", error);
+    return new Response("Error creating Openint token", { status: 500 });
+  }
+}

--- a/src/components/IntegrationButton.tsx
+++ b/src/components/IntegrationButton.tsx
@@ -3,7 +3,13 @@
 import { ConnectButton } from "@openint/connect";
 import { useEffect, useState } from "react";
 
-export function IntegrationsButton({ className }: { className?: string }) {
+export function IntegrationsButton({
+  className,
+  onPrompt,
+}: {
+  className?: string;
+  onPrompt: (prompt: string) => void;
+}) {
   const [token, setToken] = useState<string | null>();
 
   useEffect(() => {
@@ -34,15 +40,7 @@ export function IntegrationsButton({ className }: { className?: string }) {
 
   return (
     <div>
-      <p
-        style={{
-          marginBottom: "0.5rem",
-          fontSize: "1rem", // Increased font size
-          color: "#4b5563", // Darker gray text color
-        }}
-      >
-        Suggestions
-      </p>
+      <p className="mb-2 text-base text-gray-600">Suggestions</p>
       <ConnectButton
         token={token}
         text={"Manage Integrations"}
@@ -54,8 +52,15 @@ export function IntegrationsButton({ className }: { className?: string }) {
             backgroundColor: "white", // Set background to white
           } as any
         }
+        onEvent={(event) => {
+          if (event.name === "connect.connection-connected") {
+            const prompt = event?.prompt;
+            if (prompt) {
+              onPrompt(prompt);
+            }
+          }
+        }}
         className={className + " mb-2"}
-        // baseURL="http://localhost:4000/connect"
       />
     </div>
   );

--- a/src/components/IntegrationButton.tsx
+++ b/src/components/IntegrationButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ConnectButton } from "@openint/connect";
+import { useEffect, useState } from "react";
+
+export function IntegrationsButton({ className }: { className?: string }) {
+  const [token, setToken] = useState<string | null>();
+
+  useEffect(() => {
+    const fetchToken = async () => {
+      try {
+        const res = await fetch("/api/integration", {
+          method: "POST",
+        });
+        const data = await res.json();
+        if (data.token) {
+          setToken(data.token);
+        }
+      } catch (error) {
+        console.error("Error loading the integrations button", error);
+      }
+    };
+
+    fetchToken();
+  }, []);
+
+  if (!token) {
+    // if the backend does not return a token its most likely because an OPENINT_API_KEY is not set, so don't render the button
+    console.warn(
+      "No token returned from backend, not rendering integrations button"
+    );
+    return null;
+  }
+
+  return (
+    <div>
+      <p
+        style={{
+          marginBottom: "0.5rem",
+          fontSize: "1rem", // Increased font size
+          color: "#4b5563", // Darker gray text color
+        }}
+      >
+        Suggestions
+      </p>
+      <ConnectButton
+        token={token}
+        text={"Manage Integrations"}
+        buttonStyle={
+          {
+            borderRadius: "9999px",
+            padding: "0.5rem 1rem",
+            border: "none", // Remove border
+            backgroundColor: "white", // Set background to white
+          } as any
+        }
+        className={className + " mb-2"}
+        // baseURL="http://localhost:4000/connect"
+      />
+    </div>
+  );
+}

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -80,7 +80,11 @@ export default function Chat(props: {
         </ChatContainer>
       </div>
       <div className="p-3 transition-all bg-background backdrop-blur-sm z-10">
-        <IntegrationsButton />
+        <IntegrationsButton
+          onPrompt={(prompt: string) => {
+            append({ content: prompt, role: "system" });
+          }}
+        />
         <PromptInputBasic
           input={input || ""}
           onSubmit={onSubmit}

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -7,6 +7,7 @@ import { ChangeEvent, useEffect } from "react";
 import { ChatContainer } from "./ui/chat-container";
 import { Message } from "ai";
 import { ToolMessage } from "./tools";
+import { IntegrationsButton } from "./IntegrationButton";
 
 export default function Chat(props: {
   appId: string;
@@ -79,6 +80,7 @@ export default function Chat(props: {
         </ChatContainer>
       </div>
       <div className="p-3 transition-all bg-background backdrop-blur-sm z-10">
+        <IntegrationsButton />
         <PromptInputBasic
           input={input || ""}
           onSubmit={onSubmit}
@@ -130,7 +132,7 @@ function MessageBody({ message }: { message: Message }) {
                   {part.toolInvocation.result?.content?.map(
                     (content: { type: "text"; text: string }, i: number) => (
                       <div key={i}>{content.text}</div>
-                    ),
+                    )
                   )}
                   {/* Unexpectedly failed while using tool{" "}
                   {part.toolInvocation.toolName}. Please try again. again. */}

--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -20,4 +20,5 @@ Before you ever ask the user to try something, try curling the page yourself to 
 
 Sometimes if the user tells you something is broken, they might be wrong. Don't be afraid to ask them to reload the page and try again if you think the issue they're describing doesn't make sense.
 
-Integrations with third party apps are managed using the Manage Integrations button. Whenever you are integrating against a third party app that will require authentication, if the code doesn't exist in the /integrations directory, ask the user to configure the integration via the button.`;
+To talk to any third party app, inspect '/integrations' directory for the requested integration client (i.e. github.ts). If the folder or file does not exist, halt and tell the user: “Please use Manage Integrations to connect '<integration_name>' before writing any code.” DO NOT write integration code unless the user explicitly supplies custom snippets with authentication tokens.
+`

--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -18,4 +18,6 @@ When building challenging things, stop after you reach a breaking point and ask 
 
 Before you ever ask the user to try something, try curling the page yourself to ensure it's not just an error page. You shouldn't have to rely on the user to tell you when something is obviously broken.
 
-Sometimes if the user tells you something is broken, they might be wrong. Don't be afraid to ask them to reload the page and try again if you think the issue they're describing doesn't make sense.`;
+Sometimes if the user tells you something is broken, they might be wrong. Don't be afraid to ask them to reload the page and try again if you think the issue they're describing doesn't make sense.
+
+Integrations with third party apps are managed using the Manage Integrations button. Whenever you are integrating against a third party app that will require authentication, if the code doesn't exist in the /integrations directory, ask the user to configure the integration via the button.`;


### PR DESCRIPTION
This adds an integrations button powered by OpenInt. It's an example implementation meant for feedback. 

**How it works:** 
- If there's an `OPENINT_API_KEY` a Manage Integrations button is rendered. 
- The System message instructs the LLM to use the /integrations directory to get clients with managed auth for the integration
- When an end user adds an integration via the button, the onEvent handler ads a system prompt to the history. It contains already tested code with securely managed auth for said integration. 

Demo: https://www.loom.com/share/2486d9e2b8ab424b8a462e05ba7df200?sid=78bd2e1d-01cb-4f45-bbcc-80085e1bd6f6