### PR TITLE
Adding localStorage to presist the prompt input evenafter the hard re…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { PromptInput, PromptInputActions } from "@/components/ui/prompt-input";
 import { FrameworkSelector } from "@/components/framework-selector";
 import Image from "next/image";
 import LogoSvg from "@/logo.svg";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { ExampleButton } from "@/components/ExampleButton";
 import { UserButton } from "@stackframe/stack";
@@ -15,14 +15,50 @@ import { PromptInputTextareaWithTypingAnimation } from "@/components/prompt-inpu
 
 const queryClient = new QueryClient();
 
+const STORAGE_KEYS = {
+  PROMPT: "adorable_draft_prompt",
+  FRAMEWORK: "adorable_draft_framework",
+};
+
 export default function Home() {
   const [prompt, setPrompt] = useState("");
   const [framework, setFramework] = useState("nextjs");
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
+  // Load saved values from localStorage on mount
+  useEffect(() => {
+    const savedPrompt = localStorage.getItem(STORAGE_KEYS.PROMPT);
+    const savedFramework = localStorage.getItem(STORAGE_KEYS.FRAMEWORK);
+
+    if (savedPrompt) {
+      setPrompt(savedPrompt);
+    }
+    if (savedFramework) {
+      setFramework(savedFramework);
+    }
+  }, []);
+
+  // Save prompt to localStorage whenever it changes
+  useEffect(() => {
+    if (prompt) {
+      localStorage.setItem(STORAGE_KEYS.PROMPT, prompt);
+    } else {
+      localStorage.removeItem(STORAGE_KEYS.PROMPT);
+    }
+  }, [prompt]);
+
+  // Save framework to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEYS.FRAMEWORK, framework);
+  }, [framework]);
+
   const handleSubmit = async () => {
     setIsLoading(true);
+
+    // Clear saved draft after submission
+    localStorage.removeItem(STORAGE_KEYS.PROMPT);
+    localStorage.removeItem(STORAGE_KEYS.FRAMEWORK);
 
     router.push(
       `/app/new?message=${encodeURIComponent(prompt)}&template=${framework}`


### PR DESCRIPTION
Adding the hard refresh to the prompt input field


https://github.com/user-attachments/assets/0d2e2459-d6cf-4917-8818-3d42bdb2c679

---

<!-- mesa-description-start -->
## TL;DR
Persisted the prompt input to `localStorage` to prevent text from being lost on a hard refresh.

https://github.com/user-attachments/assets/0d2e2459-d6cf-4917-8818-3d42bdb2c679

## Why we made these changes
To improve the user experience by ensuring that text typed into the prompt input is not lost during an accidental page reload or navigation.

## What changed?
- The prompt input component now saves its value to `localStorage` whenever the user types.
- When the component loads, it checks `localStorage` for a saved prompt and restores it to the input field.

## Validation
- [ ] Verify that text entered in the prompt input persists after a hard refresh.
- [ ] Verify that the input field is cleared after a prompt is submitted.
- [ ] Verify that `localStorage` is cleared after submission.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/freestyle-sh/settings/pull-requests)_</sup>
<!-- mesa-description-end -->